### PR TITLE
feat: Added support for custom tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ module "labels" {
   business_unit = var.business_unit
   label_order   = var.label_order
   repository    = var.repository
+  extra_tags = var.extra_tags
 }
 
 ##-----------------------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "labels" {
   business_unit = var.business_unit
   label_order   = var.label_order
   repository    = var.repository
-  extra_tags = var.extra_tags
+  extra_tags    = var.extra_tags
 }
 
 ##-----------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -94,3 +94,9 @@ variable "notes" {
   default     = "This Resource Group is locked by terrafrom"
   description = "Specifies some notes about the lock. Maximum of 512 characters. Changing this forces a new resource to be created."
 }
+variable "extra_tags" {
+type = map(string)
+default = null
+description = "Variable to pass extra tags."
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -95,8 +95,8 @@ variable "notes" {
   description = "Specifies some notes about the lock. Maximum of 512 characters. Changing this forces a new resource to be created."
 }
 variable "extra_tags" {
-type = map(string)
-default = null
-description = "Variable to pass extra tags."
+  type        = map(string)
+  default     = null
+  description = "Variable to pass extra tags."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,12 @@ variable "managedby" {
   description = "ManagedBy, eg 'CloudDrove'."
 }
 
+variable "extra_tags" {
+  type        = map(string)
+  default     = null
+  description = "Variable to pass extra tags."
+}
+
 variable "enabled" {
   type        = bool
   default     = true
@@ -94,9 +100,3 @@ variable "notes" {
   default     = "This Resource Group is locked by terrafrom"
   description = "Specifies some notes about the lock. Maximum of 512 characters. Changing this forces a new resource to be created."
 }
-variable "extra_tags" {
-  type        = map(string)
-  default     = null
-  description = "Variable to pass extra tags."
-}
-


### PR DESCRIPTION
## what
* Add custom tags

## why
* Azure Modules only support tags from module.labels.tags, we want that any user to pass their custom tags.